### PR TITLE
Preserve executed commands in shell history

### DIFF
--- a/internal/shell/runner.go
+++ b/internal/shell/runner.go
@@ -2,8 +2,11 @@ package shell
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"time"
 )
 
 // Runner executes shell commands.
@@ -11,17 +14,54 @@ type Runner interface {
 	Run(ctx context.Context, cmd string) error
 }
 
+var commandContext = exec.CommandContext
+
 type execRunner struct{}
 
 // NewRunner returns a default shell runner.
 func NewRunner() Runner { return execRunner{} }
+
+func historyFile(shellPath string) string {
+	home := os.Getenv("HOME")
+	switch filepath.Base(shellPath) {
+	case "bash":
+		return filepath.Join(home, ".bash_history")
+	case "zsh":
+		return filepath.Join(home, ".zsh_history")
+	case "fish":
+		return filepath.Join(home, ".local", "share", "fish", "fish_history")
+	default:
+		return ""
+	}
+}
+
+func appendHistory(shellPath, cmdStr string) {
+	hf := historyFile(shellPath)
+	if hf == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(hf), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(hf, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	if filepath.Base(shellPath) == "fish" {
+		fmt.Fprintf(f, "- cmd: %s\n  when: %d\n", cmdStr, time.Now().Unix())
+	} else {
+		fmt.Fprintln(f, cmdStr)
+	}
+}
 
 func (execRunner) Run(ctx context.Context, cmdStr string) error {
 	sh := os.Getenv("SHELL")
 	if sh == "" {
 		sh = "/bin/sh"
 	}
-	c := exec.CommandContext(ctx, sh, "-c", cmdStr)
+	appendHistory(sh, cmdStr)
+	c := commandContext(ctx, sh, "-c", cmdStr)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr

--- a/internal/shell/runner_test.go
+++ b/internal/shell/runner_test.go
@@ -1,0 +1,92 @@
+package shell
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExecRunner_History_Bash(t *testing.T) {
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+	os.Setenv("SHELL", "/bin/bash")
+	old := commandContext
+	defer func() { commandContext = old }()
+	var got []string
+	commandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		got = append([]string{name}, args...)
+		return exec.CommandContext(ctx, "true")
+	}
+
+	r := NewRunner()
+	if err := r.Run(context.Background(), "echo hi"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(got) == 0 || !strings.Contains(got[0], "bash") {
+		t.Fatalf("expected bash exec, got %v", got)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".bash_history"))
+	if err != nil {
+		t.Fatalf("read history: %v", err)
+	}
+	if string(data) != "echo hi\n" {
+		t.Errorf("history content: %q", data)
+	}
+}
+
+func TestExecRunner_History_Zsh(t *testing.T) {
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+	os.Setenv("SHELL", "/bin/zsh")
+	old := commandContext
+	defer func() { commandContext = old }()
+	var got []string
+	commandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		got = append([]string{name}, args...)
+		return exec.CommandContext(ctx, "true")
+	}
+	r := NewRunner()
+	if err := r.Run(context.Background(), "echo hi"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(got) == 0 || !strings.Contains(got[0], "zsh") {
+		t.Fatalf("expected zsh exec, got %v", got)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".zsh_history"))
+	if err != nil {
+		t.Fatalf("read history: %v", err)
+	}
+	if string(data) != "echo hi\n" {
+		t.Errorf("history content: %q", data)
+	}
+}
+
+func TestExecRunner_History_Fish(t *testing.T) {
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+	os.Setenv("SHELL", "/usr/bin/fish")
+	old := commandContext
+	defer func() { commandContext = old }()
+	var got []string
+	commandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		got = append([]string{name}, args...)
+		return exec.CommandContext(ctx, "true")
+	}
+	r := NewRunner()
+	if err := r.Run(context.Background(), "echo hi"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(got) == 0 || !strings.Contains(got[0], "fish") {
+		t.Fatalf("expected fish exec, got %v", got)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".local", "share", "fish", "fish_history"))
+	if err != nil {
+		t.Fatalf("read history: %v", err)
+	}
+	if !strings.Contains(string(data), "cmd: echo hi") {
+		t.Errorf("history content: %q", data)
+	}
+}

--- a/tasks/task_19.md
+++ b/tasks/task_19.md
@@ -1,0 +1,15 @@
+Objective: Preserve executed commands in shell history
+
+Acceptance Criteria:
+- Runner appends executed commands to the user's shell history (bash, zsh, fish).
+- Unit tests cover bash, zsh, and fish cases using temporary history files.
+- E2E tests verify history updates when real shells are available.
+- All verification commands pass.
+
+Implementation Checklist:
+- [x] Update shell runner to write commands to history files.
+- [x] Add unit tests for history preservation per shell.
+- [x] Add e2e tests for bash, zsh and fish shells.
+- [x] Run golangci-lint, staticcheck, golines, go vet, go test -race.
+
+Status: Completed

--- a/test/e2e/history_test.go
+++ b/test/e2e/history_test.go
@@ -1,0 +1,48 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"command/internal/shell"
+)
+
+func runShell(t *testing.T, shellName string, historyPathParts []string, want string) {
+	t.Helper()
+	path, err := exec.LookPath(shellName)
+	if err != nil {
+		t.Skipf("%s not installed", shellName)
+	}
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("SHELL", path)
+
+	r := shell.NewRunner()
+	if err := r.Run(context.Background(), "echo hi"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	histFile := filepath.Join(append([]string{tmp}, historyPathParts...)...)
+	data, err := os.ReadFile(histFile)
+	if err != nil {
+		t.Fatalf("read history: %v", err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("expected %q in history, got %q", want, data)
+	}
+}
+
+func TestEndToEnd_History_Bash(t *testing.T) {
+	runShell(t, "bash", []string{".bash_history"}, "echo hi")
+}
+
+func TestEndToEnd_History_Zsh(t *testing.T) {
+	runShell(t, "zsh", []string{".zsh_history"}, "echo hi")
+}
+
+func TestEndToEnd_History_Fish(t *testing.T) {
+	runShell(t, "fish", []string{".local", "share", "fish", "fish_history"}, "cmd: echo hi")
+}


### PR DESCRIPTION
### What & Why
- record executed commands in user shell history files
- add unit tests for bash, zsh and fish history handling
- add e2e tests for history preservation
- document completed work in task file

### How
- `internal/shell/runner.go` now appends commands to `~/.bash_history`, `~/.zsh_history` or Fish's history file before execution
- tests verify history updates for each supported shell using temporary HOME and `exec.LookPath`

### Tests Added/Updated
- [x] Unit  -details
- [x] Integration
- [x] E2E

### Verification
```bash
$ golangci-lint run ./...
$ staticcheck ./...
$ go vet ./...
$ go test -race -coverprofile=coverage.out ./...
```

------
https://chatgpt.com/codex/tasks/task_e_6849289ab28083238cfe13808d10af14