### PR TITLE
Add post-install hook to Homebrew cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,3 +57,9 @@ homebrew_casks:
       email: actions@github.com
     commit_msg_template: "Brew cask update for {{ .ProjectName }} version {{ .Tag }}"
     directory: Casks
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/cmd"]
+          end

--- a/Casks/cmd.rb
+++ b/Casks/cmd.rb
@@ -11,4 +11,10 @@ cask "cmd" do
   homepage "https://github.com/pranjaltech/command"
 
   binary "cmd"
+
+  postflight do
+    if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+      system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/cmd"]
+    end
+  end
 end

--- a/tasks/task_disable_quarantine_on_macos.md
+++ b/tasks/task_disable_quarantine_on_macos.md
@@ -1,0 +1,15 @@
+Objective: Ensure macOS installs don't require command signing by removing the quarantine attribute.
+
+Acceptance Criteria:
+- `.goreleaser.yaml` defines a post-install hook to clear `com.apple.quarantine`.
+- `Casks/cmd.rb` includes the same post-install steps.
+- `goreleaser check` passes.
+- Verification commands succeed.
+
+Implementation Checklist:
+- [x] Update `.goreleaser.yaml` with `homebrew_casks` post-install hook.
+- [x] Update `Casks/cmd.rb` with matching uninstall step.
+- [x] Run `goreleaser check`.
+- [x] Run verification commands.
+
+Status: Completed


### PR DESCRIPTION
### What & Why
- add Homebrew postflight script in `.goreleaser.yaml` and local cask to clear the `com.apple.quarantine` attribute
- document task for traceability

### How
- updated `.goreleaser.yaml` homebrew_cask configuration with a post-install hook
- updated `Casks/cmd.rb` with `postflight` block

### Tests Added/Updated
- [ ] Unit  - none
- [ ] Integration
- [ ] E2E

### Verification
```bash
./.codex/setup.sh
golangci-lint run ./...
staticcheck ./...
golines -m 120 -w $(git ls-files '*.go')
go vet ./...
go test -race -coverprofile=coverage.out ./...
```

------
https://chatgpt.com/codex/tasks/task_e_6849dda061f08323b30a8b13f266e439