### PR TITLE
Add Linux installation support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,7 +46,7 @@ nfpms:
       - cmd
     vendor: pranjaltech
     homepage: "https://github.com/pranjaltech/command"
-    maintainer: "Pranjal <hey@pranjal.com>"
+    maintainer: "Pranjal <hey@pranjal.io>"
     description: "AI-assisted CLI that turns natural language into shell commands"
     license: MIT
     formats:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,22 @@ archives:
       - goos: windows
         formats: [zip]
 
+nfpms:
+  - id: cmd
+    package_name: cmd
+    file_name_template: "{{ .ConventionalFileName }}"
+    ids:
+      - cmd
+    vendor: pranjaltech
+    homepage: "https://github.com/pranjaltech/command"
+    maintainer: "pranjaltech"
+    description: "AI-assisted CLI that turns natural language into shell commands"
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,7 +46,7 @@ nfpms:
       - cmd
     vendor: pranjaltech
     homepage: "https://github.com/pranjaltech/command"
-    maintainer: "pranjaltech"
+    maintainer: "Pranjal <hey@pranjal.com>"
     description: "AI-assisted CLI that turns natural language into shell commands"
     license: MIT
     formats:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ curl -sSL https://raw.githubusercontent.com/pranjaltech/command/main/scripts/ins
 ```
 Downloads the latest pre-built binary and installs it to `/usr/local/bin`. Set `PREFIX` to change the location:
 ```bash
-PREFIX=$HOME/.local/bin curl -sSL https://raw.githubusercontent.com/pranjaltech/command/main/scripts/install-remote.sh | bash
+curl -sSL https://raw.githubusercontent.com/pranjaltech/command/main/scripts/install-remote.sh | PREFIX=$HOME/.local/bin bash
 ```
 
 **Debian / Ubuntu** — download the `.deb` from the [latest release](https://github.com/pranjaltech/command/releases/latest):

--- a/README.md
+++ b/README.md
@@ -5,10 +5,37 @@ A command-line helper that turns English instructions into shell commands. It ga
 ## For Users
 
 ### Install
-- **Homebrew**: `brew install --cask pranjaltech/tools/cmd`
-- **Manual build**: run `scripts/install.sh` and it will place the binary under `/usr/local/bin`.
 
-The tool works on macOS and Linux with Go 1.22+ installed.
+**macOS (Homebrew)**:
+```bash
+brew install --cask pranjaltech/tools/cmd
+```
+
+**Linux / macOS (quick install)**:
+```bash
+curl -sSL https://raw.githubusercontent.com/pranjaltech/command/main/scripts/install-remote.sh | bash
+```
+Downloads the latest pre-built binary and installs it to `/usr/local/bin`. Set `PREFIX` to change the location:
+```bash
+PREFIX=$HOME/.local/bin curl -sSL https://raw.githubusercontent.com/pranjaltech/command/main/scripts/install-remote.sh | bash
+```
+
+**Debian / Ubuntu** — download the `.deb` from the [latest release](https://github.com/pranjaltech/command/releases/latest):
+```bash
+sudo dpkg -i cmd_*_amd64.deb
+```
+
+**Fedora / RHEL** — download the `.rpm` from the [latest release](https://github.com/pranjaltech/command/releases/latest):
+```bash
+sudo rpm -i cmd-*.x86_64.rpm
+```
+
+**Build from source** (requires Go 1.22+):
+```bash
+scripts/install.sh
+```
+
+The tool works on macOS and Linux. Pre-built binaries are available for both platforms.
 
 ### What can it do?
 - Translate natural language into runnable shell commands.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/briandowns/spinner v1.20.0
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.5
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/generative-ai-go v0.19.0
 	github.com/henomis/langfuse-go v0.0.3
 	github.com/joho/godotenv v1.5.1
@@ -27,7 +28,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="pranjaltech/command"
+BINARY_NAME="cmd"
+INSTALL_DIR="${PREFIX:-/usr/local/bin}"
+
+cleanup() {
+    [ -n "${TMPDIR:-}" ] && rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# Detect OS
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$OS" in
+    linux|darwin) ;;
+    *) echo "Unsupported OS: $OS" >&2; exit 1 ;;
+esac
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64)          ARCH="amd64" ;;
+    aarch64|arm64)   ARCH="arm64" ;;
+    *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+# Determine version
+if [ -z "${VERSION:-}" ]; then
+    echo "Fetching latest release..."
+    VERSION="$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" \
+        | grep '"tag_name"' | sed -E 's/.*"v?([^"]+)".*/\1/')" || true
+    if [ -z "$VERSION" ]; then
+        echo "Could not determine latest version. Set VERSION=x.y.z and retry." >&2
+        exit 1
+    fi
+fi
+
+URL="https://github.com/${REPO}/releases/download/v${VERSION}/${BINARY_NAME}_${VERSION}_${OS}_${ARCH}.tar.gz"
+echo "Downloading ${BINARY_NAME} v${VERSION} for ${OS}/${ARCH}..."
+
+TMPDIR="$(mktemp -d)"
+curl -sSL -o "${TMPDIR}/cmd.tar.gz" "$URL"
+tar -xzf "${TMPDIR}/cmd.tar.gz" -C "$TMPDIR"
+
+mkdir -p "$INSTALL_DIR"
+if [ -w "$INSTALL_DIR" ]; then
+    install -m 755 "${TMPDIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+else
+    echo "Installing to ${INSTALL_DIR} requires elevated permissions" >&2
+    if command -v sudo >/dev/null 2>&1; then
+        sudo install -m 755 "${TMPDIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+    else
+        echo "sudo not found. Set PREFIX to a writable directory and retry." >&2
+        exit 1
+    fi
+fi
+
+echo "Installed ${BINARY_NAME} v${VERSION} to ${INSTALL_DIR}/${BINARY_NAME}"
+"${INSTALL_DIR}/${BINARY_NAME}" --version


### PR DESCRIPTION
## Summary

- Add nfpm configuration to `.goreleaser.yaml` for generating `.deb` and `.rpm` packages
- Create `scripts/install-remote.sh` for OS-agnostic binary download and installation via curl
- Update README with native Linux package manager instructions (Debian/Ubuntu and Fedora/RHEL) and a convenient one-liner installer

## Implementation

The Go code was already cross-platform with static binaries. These changes enable convenient installation on Linux systems without requiring the Go toolchain. Users can now install via:
- **dpkg** on Debian/Ubuntu: download `.deb` from releases
- **rpm** on Fedora/RHEL: download `.rpm` from releases  
- **curl** on any distro: `curl -sSL .../install-remote.sh | bash`

Existing macOS Homebrew Cask and build-from-source methods remain unchanged.

## Verification

- `goreleaser check` validates the configuration
- All unit/integration tests pass
- The curl installer follows the same patterns as the existing `scripts/install.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)