### PR TITLE
Style-clean the GoReleaser-generated Homebrew cask before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,15 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # GoReleaser writes the cask to dist/ but does not push it (skip_upload).
+      # We style it with the same Homebrew/rubocop the tap CI uses, then publish.
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Homebrew cask
+        run: ./scripts/publish-cask.sh
+        env:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,9 +73,17 @@ homebrew_casks:
       email: actions@github.com
     commit_msg_template: "Brew cask update for {{ .ProjectName }} version {{ .Tag }}"
     directory: Casks
+    # GoReleaser only writes the cask to dist/; the release workflow then runs
+    # `brew style --fix` on it before committing to the tap. This keeps the
+    # published cask in sync with Homebrew's rubocop (which tightened in 6.0.3)
+    # without relying on GoReleaser's template emitting canonical formatting.
+    # See scripts/publish-cask.sh and .github/workflows/release.yml.
+    skip_upload: "true"
     hooks:
       post:
+        # Use `.zero?` (Style/NumericPredicate) rather than `== 0` so the
+        # generated postflight block is already brew-style clean.
         install: |
-          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status.zero?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/cmd"]
           end

--- a/scripts/publish-cask.sh
+++ b/scripts/publish-cask.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publish the GoReleaser-generated Homebrew cask to the tap.
+#
+# GoReleaser writes the cask to dist/ (homebrew_casks.skip_upload is "true"),
+# but its template does not always match Homebrew's rubocop (e.g. the trailing
+# blank line before `end` that Homebrew 6.0.3+ flags as
+# Layout/EmptyLinesAroundBlockBody). The tap's CI runs `brew test-bot
+# --only-tap-syntax` (i.e. `brew style`) and goes red on any offense, so we run
+# `brew style --fix` here — inside a real tap checkout, where the Cask/* cops
+# apply — before committing. This way the file that lands in the tap is already
+# style-clean regardless of how GoReleaser's template evolves.
+#
+# Requires (provided by the release workflow):
+#   - brew on PATH (Homebrew/actions/setup-homebrew)
+#   - HOMEBREW_TAP_GITHUB_TOKEN with write access to the tap
+#   - GITHUB_REF_NAME set to the release tag (falls back to `git describe`)
+
+# `TAP` is the Homebrew short name (maps to the GitHub repo pranjaltech/
+# homebrew-tools); `TAP_REPO` is that GitHub repo, used for the push URL.
+TAP="pranjaltech/tools"
+TAP_REPO="pranjaltech/homebrew-tools"
+CASK_NAME="cmd"
+GENERATED="dist/homebrew/Casks/${CASK_NAME}.rb"
+TAG="${GITHUB_REF_NAME:-$(git describe --tags --abbrev=0)}"
+
+if [[ ! -f "$GENERATED" ]]; then
+    echo "::error::generated cask not found at ${GENERATED}" >&2
+    exit 1
+fi
+if [[ -z "${HOMEBREW_TAP_GITHUB_TOKEN:-}" ]]; then
+    echo "::error::HOMEBREW_TAP_GITHUB_TOKEN is not set" >&2
+    exit 1
+fi
+
+# Clone the tap into Homebrew's taps directory. `brew style` only applies the
+# Cask/* cops when the file lives inside a registered tap, so styling the loose
+# dist/ file would lint it as plain Ruby and miss/misreport offenses.
+brew tap "$TAP"
+TAP_DIR="$(brew --repository "$TAP")"
+CASK_PATH="${TAP_DIR}/Casks/${CASK_NAME}.rb"
+
+cp "$GENERATED" "$CASK_PATH"
+
+# Normalise to the current Homebrew rubocop, then hard-fail if anything is left
+# uncorrected so a malformed cask never reaches the tap.
+brew style --fix "$CASK_PATH"
+brew style "$CASK_PATH"
+
+cd "$TAP_DIR"
+git config user.name "GitHub Actions"
+git config user.email "actions@github.com"
+git add "Casks/${CASK_NAME}.rb"
+
+if git diff --cached --quiet; then
+    echo "Cask ${CASK_NAME} is unchanged; nothing to publish."
+    exit 0
+fi
+
+git commit -m "Brew cask update for ${CASK_NAME} version ${TAG}"
+git remote set-url origin \
+    "https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/${TAP_REPO}.git"
+git push origin HEAD:main
+
+echo "Published style-clean cask for ${CASK_NAME} ${TAG} to ${TAP_REPO}."

--- a/tasks/task_brew_style_clean_cask.md
+++ b/tasks/task_brew_style_clean_cask.md
@@ -1,0 +1,41 @@
+Objective: Make the GoReleaser-generated Homebrew cask (`Casks/cmd.rb` in the
+pranjaltech/homebrew-tools tap) pass `brew style` so the tap's
+`brew test-bot --only-tap-syntax` CI is green. Homebrew 6.0.3 tightened rubocop
+and the generated cask started failing.
+
+Offenses to eliminate (Homebrew 6.0.3, `brew style pranjaltech/tools`):
+- `Cask/StanzaOrder` — desc/homepage/version emitted out of canonical order.
+- `Cask/StanzaGrouping` — stanza groups not separated by a single blank line.
+- `Style/NumericPredicate` — `.exit_status == 0` in the postflight block.
+- `Layout/EmptyLinesAroundBlockBody` — blank line before the final `end`
+  (surfaced by current GoReleaser; introduced after the tap's last release).
+
+Acceptance Criteria:
+- The cask GoReleaser publishes to the tap is `brew style`-clean (0 offenses).
+- The fix lives in this repo (not hand-edits to the generated, DO-NOT-EDIT cask).
+- `goreleaser check` passes and the release workflow stays valid.
+
+Findings:
+- Current GoReleaser (v2.16.0, what `~> v2` resolves to) already emits canonical
+  StanzaOrder/StanzaGrouping — those two offenses are gone with the new template.
+- `Style/NumericPredicate` comes from this repo's `homebrew_casks.hooks.post.install`
+  snippet; fixed at the source by using `.exit_status.zero?`.
+- `Layout/EmptyLinesAroundBlockBody` (the trailing blank before `end`) is hardcoded
+  in GoReleaser's template and cannot be removed via config (adding `zap`/stanzas to
+  fill the space only introduces new offenses). It must be post-processed.
+
+Implementation Checklist:
+- [x] `.goreleaser.yaml`: use `.exit_status.zero?` in the postflight hook.
+- [x] `.goreleaser.yaml`: set `homebrew_casks.skip_upload: "true"` so GoReleaser
+      writes the cask to dist/ but does not push the un-styled file.
+- [x] Add `scripts/publish-cask.sh`: style the generated cask with `brew style --fix`
+      inside a real tap checkout (where the Cask/* cops apply), hard-fail on any
+      remaining offense, then commit/push it to the tap.
+- [x] `.github/workflows/release.yml`: add `Homebrew/actions/setup-homebrew` (same as
+      the tap CI) and run the publish script with `HOMEBREW_TAP_GITHUB_TOKEN`.
+- [x] Verify: `goreleaser release --snapshot` then `brew style --fix` in tap context
+      yields `no offenses detected`.
+- [x] Verify: full clone→copy→style→commit→push simulation against a local bare
+      remote; the pushed cask re-styles clean.
+
+Status: Completed


### PR DESCRIPTION
### What & Why
- Homebrew **6.0.3** tightened its rubocop, and the auto-generated `Casks/cmd.rb` in the **pranjaltech/homebrew-tools** tap began failing `brew style`, turning the tap's `brew test-bot --only-tap-syntax` CI red on every push/PR.
- The generated cask carries `# This file was generated by GoReleaser. DO NOT EDIT.`, so the fix belongs **here** in the release flow — hand-edits in the tap are overwritten every release.

Offenses observed via `brew style pranjaltech/tools` (Homebrew 6.0.3) on the tap's current cask:
- `Cask/StanzaOrder` — `desc`/`homepage`/`version` out of canonical order
- `Cask/StanzaGrouping` — stanza groups not separated by single blank lines
- `Style/NumericPredicate` — `.exit_status == 0` in the `postflight` block
- `Layout/EmptyLinesAroundBlockBody` — blank line before the final `end` (surfaced by current GoReleaser)

### How
- **`.goreleaser.yaml`**
  - postflight hook now uses `.exit_status.zero?` instead of `== 0` (fixes `Style/NumericPredicate` at the source).
  - `homebrew_casks.skip_upload: "true"` — GoReleaser writes the cask to `dist/` but no longer pushes the un-styled file to the tap.
- **`scripts/publish-cask.sh`** (new) — runs `brew style --fix` on the generated cask **inside a real tap checkout** (the `Cask/*` cops only apply within a registered tap), hard-fails if any offense remains, then commits/pushes to the tap. This keeps the published cask clean regardless of how GoReleaser's template formats things in the future.
- **`.github/workflows/release.yml`** — adds `Homebrew/actions/setup-homebrew@master` (the same setup the tap CI uses, so identical rubocop rules) and runs the publish script with `HOMEBREW_TAP_GITHUB_TOKEN`.

#### Why a post-generation step (not config-only)
Current GoReleaser (v2.16.0, what `~> v2` resolves to) **already** emits canonical `StanzaOrder`/`StanzaGrouping` — those two offenses are gone with the newer template. `Style/NumericPredicate` is fixed in config. The remaining `Layout/EmptyLinesAroundBlockBody` (trailing blank before `end`) is hardcoded in GoReleaser's template and **cannot** be removed via config (adding `zap`/stanzas to fill the space only introduces *new* offenses), so it is corrected by `brew style --fix`.

### Tests Added/Updated
- [ ] Unit — n/a (release tooling/CI change)
- [ ] Integration — n/a
- [ ] E2E — manual, see Verification

### Verification
Performed locally against Homebrew **6.0.3** (the exact version in the report) and GoReleaser **v2.16.0**:
- `goreleaser check` → config valid.
- `goreleaser release --snapshot --clean` → cask written to `dist/`; `brew style --fix` on it in tap context → **`1 file inspected, no offenses detected`**.
- Reproduced the original 13 offenses on the tap's current cask, confirming the diagnosis.
- Full clone → copy → `brew style --fix` → commit → push simulation against a throwaway local bare remote; the pushed cask re-styles clean (`no offenses detected`). The real tap was left untouched.

```bash
$ goreleaser check && goreleaser release --snapshot --clean
$ brew style --fix <tap>/Casks/cmd.rb && brew style <tap>/Casks/cmd.rb
1 file inspected, no offenses detected
```

> Sibling follow-up (separate task): bump `Formula/scribe.rb` to 0.13.0 + fix its style offenses — the other reason tap CI is red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kfcRQ9QRHXmKCkMjQmPzW